### PR TITLE
fix: fix wrong hook type in AutoTool

### DIFF
--- a/src/coral_fans/functions/func/AutoTool.cpp
+++ b/src/coral_fans/functions/func/AutoTool.cpp
@@ -46,7 +46,7 @@ int searchBestToolInInv(Container& inv, int currentSlot, const Block* block, con
 
 namespace coral_fans::functions {
 
-LL_AUTO_TYPE_INSTANCE_HOOK(
+LL_TYPE_INSTANCE_HOOK(
     CoralFansTweakersAutoToolHook1,
     ll::memory::HookPriority::Normal,
     BlockEventCoordinator,
@@ -78,7 +78,7 @@ LL_AUTO_TYPE_INSTANCE_HOOK(
     origin(player, blockPos, block, unk_char);
 }
 
-LL_AUTO_TYPE_INSTANCE_HOOK(
+LL_TYPE_INSTANCE_HOOK(
     CoralFansTweakersAutoToolHook2,
     ll::memory::HookPriority::Normal,
     Player,


### PR DESCRIPTION
## What does this PR do?

Fix wrong hook macro in AutoTool.cpp

## Which issues does this PR resolve?

#27 

## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] Your code follows [LeviLamina C++ Style Guide](https://github.com/LiteLDev/LeviLamina/wiki/CPP-Style-Guide)
- [x] You have tested all functions
- [x] You have not used code without license
- [x] You have added statement for third-party code
